### PR TITLE
Fix fonts on mac and Linux

### DIFF
--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/awt/font/AwtFontUtils.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/awt/font/AwtFontUtils.kt
@@ -127,7 +127,9 @@ internal object AwtFontUtils {
 
             CFontClass?.isInstance(font2D) == true -> {
                 // For macOS
-                getFieldValueOrNull(CFontClass, font2D, String::class.java, "nativeFontName")
+                val nativeFontName =
+                    getFieldValueOrNull(CFontClass, font2D, String::class.java, "nativeFontName")
+                Font(nativeFontName, Font.PLAIN, 10).fontFamilyName
             }
 
             else -> error("Unsupported Font2D subclass: ${font2D.javaClass.name}")

--- a/skiko/src/awtMain/kotlin/org/jetbrains/skiko/awt/font/SkiaFontProvider.kt
+++ b/skiko/src/awtMain/kotlin/org/jetbrains/skiko/awt/font/SkiaFontProvider.kt
@@ -118,7 +118,9 @@ internal object SkiaFontProvider : FontProvider {
     override suspend fun getTypefaceOrNull(familyName: String, fontStyle: FontStyle): Typeface? {
         ensureSystemFontsCached()
 
-        val key = FontFamilyKey(familyName)
+        // trim because we can have spaces on Linux (real example - "Mitra " font family)
+        val fontFamilyFixed = familyName.trim()
+        val key = FontFamilyKey(fontFamilyFixed)
 
         if (isAppleSystemFont(key)) {
             // Rewrite requests for ".AppleSystemUIFont" on macOS to "System font".
@@ -134,7 +136,7 @@ internal object SkiaFontProvider : FontProvider {
 
         if (!familyNamesCache.contains(key)) return null
 
-        return FontMgr.default.matchFamilyStyle(familyName, fontStyle)
+        return FontMgr.default.matchFamilyStyle(fontFamilyFixed, fontStyle)
     }
 
     private fun isAwtLogicalFont(key: FontFamilyKey) =
@@ -143,14 +145,16 @@ internal object SkiaFontProvider : FontProvider {
     override suspend fun getFontFamilyOrNull(familyName: String): FontFamily? {
         ensureSystemFontsCached()
 
-        val key = FontFamilyKey(familyName)
+        // trim because we can have spaces on Linux (real example - "Mitra " font family)
+        val fontFamilyFixed = familyName.trim()
+        val key = FontFamilyKey(fontFamilyFixed)
 
         if (isAppleSystemFont(key)) {
             // Rewrite requests for ".AppleSystemUIFont" on macOS to "System font".
             // They are the same, hidden San Francisco font, but we need to do this
             // for AWT compatibility reasons.
             return FontMgr.default.matchFamily(FontFamilyKey.Apple.SystemFont.familyName)
-                .use { it.toFontFamilyOrNull(familyName, FontFamily.FontFamilySource.System) }
+                .use { it.toFontFamilyOrNull(fontFamilyFixed, FontFamily.FontFamilySource.System) }
         }
 
         if (!familyNamesCache.contains(key)) return null

--- a/skiko/src/awtTest/kotlin/org/jetbrains/skiko/awt/font/AwtFontManagerTest.kt
+++ b/skiko/src/awtTest/kotlin/org/jetbrains/skiko/awt/font/AwtFontManagerTest.kt
@@ -69,7 +69,9 @@ class AwtFontManagerTest {
         val ignoredFamilies = setOf(
             "Franklin Gothic Medium",
             "Segoe UI Variable",
-            "Sitka"
+            "Sitka",
+            "Roboto Light",
+            "Roboto Thin"
         )
 
         // Listing of font family names is broken on non-macOS JVM implementations,
@@ -95,8 +97,15 @@ class AwtFontManagerTest {
         for (i in awtFamilies.indices) {
             val awtFamily = awtFamilies[i]
             val skiaFamily = skiaFamilies[i]
-            if (awtFamily != skiaFamily && awtFamily !in ignoredFamilies) {
-                wrongConversions.add("$awtFamily -> $skiaFamily")
+            when {
+                awtFamily == ".AppleSystemUIFont" -> {
+                    if (skiaFamily == null) {
+                        wrongConversions.add("$awtFamily -> null")
+                    }
+                }
+                awtFamily != skiaFamily && awtFamily !in ignoredFamilies -> {
+                    wrongConversions.add("$awtFamily -> $skiaFamily")
+                }
             }
         }
 


### PR DESCRIPTION
- Fix logical fonts on macOS (nativeFontName return file name, not family name):
```
TimesNewRomanPSMT
LucidaGrande
Menlo-Regular
```
It should be:
```
Times New Roman
Lucida Grande
Menlo
```
- Fix fonts on Linux (some fonts can have spaces)
- Ignore the variable Roboto in the test (fails on macOs)